### PR TITLE
docs: corrección definitiva de schema y reglas de negocio basada en código real

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -399,7 +399,7 @@ Estas reglas aplican a **todo código nuevo** en este servicio:
 ```json
 {
   "id": 1,
-  "ticket_id": 42,
+  "ticket_id": "42",
   "message": "Nuevo Ticket #42 creado: Error en login",
   "read": false,
   "sent_at": "2025-01-15T10:30:00Z"
@@ -408,11 +408,22 @@ Estas reglas aplican a **todo código nuevo** en este servicio:
 
 | Campo       | Tipo     | Descripción                                      |
 |-------------|----------|--------------------------------------------------|
-| `id`        | integer  | Identificador único autoincremental              |
-| `ticket_id` | integer  | ID del ticket asociado (entero, consistente con el contrato de eventos) |
-| `message`   | string   | Contenido descriptivo de la notificación         |
-| `read`      | boolean  | Estado de lectura (`false` por defecto)          |
-| `sent_at`   | datetime | Fecha y hora de creación (ISO 8601 UTC)          |
+| `id`        | integer  | Identificador único autoincremental |
+| `ticket_id` | string   | ID del ticket asociado. Recibido como `int` desde eventos RabbitMQ, almacenado y expuesto como `string` (`CharField` en el modelo) |
+| `message`   | string   | Contenido descriptivo de la notificación |
+| `read`      | boolean  | Estado de lectura (`false` por defecto) |
+| `sent_at`   | datetime | Fecha y hora de creación (ISO 8601 UTC). Generado automáticamente por el servidor (`auto_now_add=True`) |
+
+> ℹ️ **Campos internos no expuestos por la API**
+>
+> Los siguientes campos existen en el modelo (`models.py`) y en la entidad de dominio
+> (`domain/entities.py`) pero **no forman parte del contrato público de la API REST**
+> porque no están incluidos en `serializers.py`:
+>
+> | Campo | Tipo | Uso interno |
+> |-------|------|-------------|
+> | `user_id` | string | ID del usuario destinatario. Usado para filtrado y asociación interna |
+> | `response_id` | integer (nullable) | Clave de idempotencia para `ticket.response_added`. Evita crear notificaciones duplicadas por la misma respuesta |
 
 ### Ejemplo de respuesta exitosa — GET /api/notifications/
 
@@ -421,14 +432,14 @@ HTTP 200 OK
 [
   {
     "id": 1,
-    "ticket_id": 42,
+    "ticket_id": "42",
     "message": "Nuevo Ticket #42 creado: Error en login",
     "read": false,
     "sent_at": "2025-01-15T10:30:00Z"
   },
   {
     "id": 2,
-    "ticket_id": 42,
+    "ticket_id": "42",
     "message": "El administrador respondió el Ticket #42",
     "read": true,
     "sent_at": "2025-01-15T11:00:00Z"
@@ -441,7 +452,7 @@ HTTP 200 OK
 ```json
 HTTP 404 Not Found
 {
-  "detail": "No found."
+  "detail": "Not found."
 }
 ```
 
@@ -684,14 +695,14 @@ GET /api/notifications/
 [
   {
     "id": 3,
-    "ticket_id": 103,
+    "ticket_id": "103",
     "message": "El estado de tu ticket 'Error en facturación' cambió a in_progress.",
     "read": false,
     "sent_at": "2026-02-11T16:00:00Z"
   },
   {
     "id": 1,
-    "ticket_id": 101,
+    "ticket_id": "101",
     "message": "Tu ticket 'Error en facturación' fue creado exitosamente.",
     "read": false,
     "sent_at": "2026-02-11T14:00:00Z"
@@ -718,7 +729,7 @@ GET /api/notifications/{id}/
 ```json
 {
   "id": 42,
-  "ticket_id": 101,
+  "ticket_id": "101",
   "message": "Tu ticket 'Error en facturación' fue creado exitosamente.",
   "read": false,
   "sent_at": "2026-02-11T14:00:00Z"
@@ -747,21 +758,21 @@ POST /api/notifications/
 **Request Body:**
 ```json
 {
-  "ticket_id": 101,
+  "ticket_id": "101",
   "message": "Tu ticket 'Error en facturación' fue creado exitosamente."
 }
 ```
 
 | Campo       | Tipo    | Requerido | Descripción |
 |-------------|---------|-----------|-------------|
-| `ticket_id` | integer | ✅        | Identificador del ticket relacionado |
+| `ticket_id` | string  | ✅        | Identificador del ticket relacionado |
 | `message`   | string  | ✅        | Contenido de la notificación |
 
 **Response 201 Created:**
 ```json
 {
   "id": 43,
-  "ticket_id": 101,
+  "ticket_id": "101",
   "message": "Tu ticket 'Error en facturación' fue creado exitosamente.",
   "read": false,
   "sent_at": "2026-02-11T14:30:00Z"
@@ -772,7 +783,7 @@ POST /api/notifications/
 ```json
 {
   "ticket_id": ["This field is required."],
-  "user_id": ["This field is required."]
+  "message": ["This field is required."]
 }
 ```
 
@@ -796,7 +807,7 @@ PATCH /api/notifications/{id}/read/
 ```json
 {
   "id": 42,
-  "ticket_id": 101,
+  "ticket_id": "101",
   "message": "Tu ticket 'Error en facturación' fue creado exitosamente.",
   "read": true,
   "sent_at": "2026-02-11T14:00:00Z"

--- a/USERSTORIES Y CRITERIOS DE ACEPTACION.md
+++ b/USERSTORIES Y CRITERIOS DE ACEPTACION.md
@@ -138,6 +138,9 @@ Feature: Notificación por respuesta agregada a ticket
     Then se persiste una notificación asociada al user_id del evento
     And el message de la notificación referencia al ticket_id y la existencia de una nueva respuesta
     And el campo response_id queda almacenado en la notificación
+    And el response_id queda persistido internamente como clave de idempotencia
+    And el response_id NO es expuesto en la respuesta de la API REST
+    And el body de la respuesta solo contiene: id, ticket_id, message, read, sent_at
     And la notificación queda en estado no leída
     And el mensaje es confirmado (ack) en la cola
 
@@ -196,6 +199,16 @@ T: ✅ Escenarios observables y verificables por QA en consumer tests.
 
 ### US-E1-03 — Crear notificación al recibir evento `ticket.status_changed`
 
+> ⚠️ **BLOQUEADA PARCIALMENTE — DT-09**
+> El contrato oficial del evento `ticket.status_changed` definido en
+> `copilot-instructions.md` **no incluye `user_id`**:
+> ```json
+> { "event_type": "ticket.status_changed", "ticket_id": int, "old_status": str, "new_status": str, "timestamp": "ISO8601" }
+> ```
+> Sin `user_id`, el servicio no puede determinar a qué usuario asociar la
+> notificación. El Scenario feliz representa el **estado objetivo** una vez
+> que el ticket-service extienda el contrato. Ver DT-09 en ARCHITECTURE.md.
+
 **Como** notification-service
 **quiero** procesar el evento `ticket.status_changed`
 **para** informar al usuario que el estado de su ticket fue actualizado por un administrador
@@ -242,6 +255,18 @@ Feature: Notificación por cambio de estado de ticket
     Then no se persiste ninguna notificación
     And el mensaje es enviado a la Dead Letter Queue
     And se registra un log de error estructurado
+```
+
+```gherkin
+  Scenario: Evento ticket.status_changed sin user_id va a Dead Letter Queue (comportamiento actual)
+    Given el consumer está activo y conectado a RabbitMQ
+    When llega un evento con event_type "ticket.status_changed"
+    And el payload contiene ticket_id, old_status, new_status y timestamp
+    And el campo user_id NO está presente en el payload
+    Then el consumer captura la ausencia del campo user_id
+    And envía el mensaje a la Dead Letter Queue con NACK requeue=False
+    And no se crea ninguna notificación en la base de datos
+    And se registra un log de error con el ticket_id y el motivo "missing user_id"
 ```
 
 #### Notas
@@ -488,7 +513,7 @@ Feature: Consultar notificación por ID
     Given existe una notificación con id 42
     When el frontend realiza un GET a /api/notifications/42/
     Then la respuesta tiene código HTTP 200
-    And el body contiene los campos: id, message, read, ticket_id, user_id, created_at
+    And el body contiene los campos: id, ticket_id, message, read, sent_at
     And el campo id del body es 42
 
   Scenario: Consulta de notificación inexistente
@@ -888,7 +913,7 @@ Feature: Entorno local completo con docker-compose
   Scenario: Levantamiento exitoso del ecosistema
     Given el archivo docker-compose.yml está en la raíz del proyecto
     When ejecuto `docker-compose up --build`
-    Then el notification-service responde en `http://localhost:8003/api/notifications/`
+    Then el notification-service responde en `http://localhost:8001/api/notifications/`
     And PostgreSQL está accesible y las migraciones fueron aplicadas
     And RabbitMQ está accesible en `localhost:15672`
 


### PR DESCRIPTION
## ¿Qué cambia este PR?
Correcciones finales basadas en inspección directa del código real del monorepo.
Cierra toda discrepancia entre la documentación y el sistema funcionando hoy.

## Fuentes de verdad usadas
- `notifications/models.py` → `ticket_id` es `CharField` (string)
- `notifications/serializers.py` → expone solo `id, ticket_id, message, sent_at, read`
- `notifications/domain/entities.py` → `user_id` y `response_id` son campos internos
- `docker-compose.yml` → `notification-service` usa puerto `8001`
- `copilot-instructions.md` → `ticket.status_changed` no incluye `user_id`

## Cambios en ARCHITECTURE.md
- ✅ `ticket_id` corregido a string en schema, tabla y todos los ejemplos JSON
- ✅ Nota agregada: `user_id` y `response_id` son campos internos no expuestos
- ✅ Error 400 de POST corregido (`message` en lugar de `user_id`)
- ✅ Typo `"No found."` → `"Not found."` corregido

## Cambios en USERSTORIES
- ✅ US-E2-02: campos del body alineados con serializers.py
- ✅ US-E1-02: `response_id` aclarado como campo interno de idempotencia
- ✅ US-E1-03: bloqueada por DT-09 con Scenario de comportamiento actual (DLQ)
- ✅ US-INFRA-02: puerto corregido `8003` → `8001`

## Checklist de verificación
- [ ] `ticket_id` es string en todos los ejemplos de ambos documentos
- [ ] Los 5 campos del contrato API son: `id, ticket_id, message, read, sent_at`
- [ ] `user_id` y `response_id` solo aparecen como campos internos
- [ ] Puerto `8001` consistente en ambos documentos, sin menciones de `8003` para notification-service
- [ ] DT-09 referenciado desde US-E1-03 y tabla de idempotencia
- [ ] Solo `ticket.created` y `ticket.response_added` documentados como implementados hoy

## Issue relacionado
Closes #5