### PR TITLE
docs: reescribir copilot-instructions.md específico para este repositorio

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,192 +1,85 @@
-# Project Copilot Instructions — Ticket Microservices System
+# Copilot Instructions — backend-notification-service
 
-## Architecture Overview
+Microservicio Django de notificaciones extraído del monorepo `SistemaTickets`.
+Puerto externo: `8001`. API base: `http://localhost:8001/api/notifications/`.
 
-This repository implements a microservices-based ticketing system composed of:
+## Architecture (DDD Pragmático — already implemented)
 
-- **Ticket Service** (backend/ticket-service): Gestión de tickets y estados. Referencia DDD.
-- **Assignment Service** (backend/assignment-service): Asignación de tickets a agentes.
-- **Notification Service** (backend/notification-service): Gestión de notificaciones.
-- **User Service** (backend/users-service): Usuarios y autenticación.
-- **Frontend** (frontend/): SPA React + TypeScript.
-
-**Stack:** Django 5.x, DRF, RabbitMQ (Pika), PostgreSQL 16, React 19, Vite, Vitest. Testing backend: Pytest.
-
-Ticket Service follows Domain Driven Design (DDD).
-Other services are being progressively aligned to this architecture.
-
-When generating code:
-
-- NEVER couple services via database imports
-- ALWAYS communicate via REST API or domain events
-- Prefer event-driven integration over synchronous coupling
-
----
-
-## Business Rules (Reglas de Negocio)
-
-### Tickets (Ticket Service)
-- **Estados válidos:** `OPEN`, `IN_PROGRESS`, `CLOSED` (transición: OPEN → IN_PROGRESS → CLOSED)
-- **Regla:** Un ticket en estado `CLOSED` NO puede cambiar de estado → lanzar excepción de dominio `TicketAlreadyClosed`
-- **Creación:** Ticket nuevo siempre inicia en `OPEN`. Título y descripción obligatorios.
-- **Eventos:** Tras crear ticket → publicar `ticket.created`; tras cambio de estado válido → publicar `ticket.status_changed` (ver esquemas abajo)
-- **Idempotencia:** Si el ticket ya tiene el estado solicitado, no hacer cambio ni publicar evento
-
-**Contratos de eventos (mantener compatibilidad):**
-
-`ticket.created`:
-```json
-{ "event_type": "ticket.created", "ticket_id": int, "title": str, "user_id": int, "status": "open", "timestamp": "ISO8601" }
+```
+domain/         ← Python puro. Zero Django imports. Entities, events, exceptions, repository ABC.
+application/    ← Use cases + Commands (dataclasses). Orchestrate domain, no ORM.
+infrastructure/ ← DjangoNotificationRepository, RabbitMQEventPublisher.
+api.py          ← Thin ViewSet. Delegates 100% to use cases. No business logic.
+models.py       ← ORM only. Infrastructure layer. Never import from domain.
+messaging/consumer.py ← Standalone process. Dispatches to use cases or ORM fallback.
 ```
 
-`ticket.status_changed`:
-```json
-{ "event_type": "ticket.status_changed", "ticket_id": int, "old_status": str, "new_status": str, "timestamp": "ISO8601" }
+Dependency rule (strict): `domain ← application ← infrastructure ← presentation`
+
+## Critical Asymmetry (current state)
+
+`ticket.response_added` → `_handle_response_added()` → `CreateNotificationFromResponseUseCase` ✅ DDD  
+All other events → `_handle_ticket_created()` → `Notification.objects.create()` ⚠️ ORM direct (DT-01, DT-07, DT-08)
+
+Adding a new event handler means creating a Use Case + Command, not touching the ORM in the consumer.
+
+## API Contract
+
+Serializer exposes exactly **5 fields**: `id`, `ticket_id` (string), `message`, `read`, `sent_at`.  
+`user_id` and `response_id` exist in `models.py` but are **intentionally excluded** from `serializers.py` — internal fields only.
+
+`ticket_id` arrives as `int` from RabbitMQ → stored/exposed as `str` via `CharField`. Always `str(ticket_id)`.
+
+## Event Contracts (RabbitMQ, fanout exchange)
+
+| Event | Required fields | Handler |
+|---|---|---|
+| `ticket.created` | `ticket_id`, `title`, `user_id`, `status`, `timestamp` | `_handle_ticket_created` (ORM) |
+| `ticket.response_added` | `ticket_id`, `response_id`, `admin_id`, `response_text`, `user_id`, `timestamp` | Use Case |
+| `ticket.status_changed` | `ticket_id`, `old_status`, `new_status`, `timestamp` — **no `user_id`** | `_handle_ticket_created` (ORM) — DT-09 blocked |
+| `ticket.priority_changed` | TBD | `_handle_ticket_created` (ORM) — DT-07/08 pending |
+
+`InvalidEventSchema` → `basic_nack(requeue=False)` → Dead Letter Queue (`{queue}.dlq`).
+
+## Use Case Pattern
+
+```python
+# 1. Command (dataclass in application/use_cases.py)
+@dataclass
+class CreateNotificationFromResponseCommand:
+    ticket_id: Any; response_id: Optional[int]; user_id: Any; ...
+
+# 2. Use Case (takes repository + optional event_publisher via __init__)
+class CreateNotificationFromResponseUseCase:
+    def __init__(self, repository: NotificationRepository): ...
+    def execute(self, command: ...) -> Notification: ...
+
+# 3. ViewSet wires DI in __init__, never in request handlers
+self.repository = DjangoNotificationRepository()
+self.mark_as_read_use_case = MarkNotificationAsReadUseCase(repository=..., event_publisher=...)
 ```
 
-### Asignación (Assignment Service)
-- **Regla:** Al recibir evento `ticket.created`, asignar un agente al ticket
-- **Prioridad:** Actualmente lógica placeholder (aleatoria). Al evolucionar, usar reglas de negocio (carga, SLA, roles) en capa de dominio, no en handler
+## Developer Workflows
 
-### Notificaciones (Notification Service)
-- **Regla:** Al recibir `ticket.created` (y otros eventos definidos), crear notificación correspondiente y persistirla
-- **Responsabilidad:** La regla de qué notificar vive en dominio; el handler solo orquesta
+```bash
+# Tests (uses notification_service.test_settings — not settings.py)
+pytest
 
-### Usuarios (User Service)
-- **Roles:** Usuario estándar vs agente
-- **Comunicación:** Otros servicios NO deben importar modelos de User Service ni acceder a `users_db`. Usar API REST o eventos
-- **Objetivo:** User Service aún no publica eventos; al integrarlo en EDA, emitir eventos ante cambios de usuario/rol
+# Run with coverage
+pytest --cov=notifications --cov-report=term-missing
 
-### Referencias de documentación
-- Reglas detalladas y riesgos: [HANDOVER_REPORT.md](HANDOVER_REPORT.md), [AUDITORIA.md](AUDITORIA.md), [DEUDA_TECNICA.md](DEUDA_TECNICA.md), [CALIDAD.md](CALIDAD.md)
-- Arquitectura DDD por servicio: `backend/ticket-service/ARCHITECTURE_DDD.md`
+# Start consumer (standalone process, separate from Django)
+python -m notifications.messaging.consumer
 
----
+# Migrations
+python manage.py migrate
+```
 
-# Coding Philosophy
+## Key Files
 
-## Type Hints
-- **Ticket Service:** 100% type hints (mantener).
-- **Assignment, Notification, User Services:** Extender type hints en código nuevo. Priorizar dominio y casos de uso.
-- Usar anotaciones en funciones públicas y constructores.
-
-## Clean Architecture Priority
-
-Always respect layer separation:
-
-Domain → Application → Infrastructure → Presentation
-
-Rules:
-
-- Domain must be pure Python (no Django imports)
-- Business logic must NOT exist in Django Views
-- Messaging handlers must delegate to Use Cases
-- ORM models belong ONLY to infrastructure
-
-
----
-
-# Naming Conventions
-
-## Python
-
-- Classes → PascalCase
-- Functions → snake_case
-- Variables → snake_case
-- Constants → UPPER_CASE
-
-## TypeScript / React
-
-- Components → PascalCase
-- Hooks → camelCase
-- Variables → camelCase
-
-
----
-
-# Error Handling Rules
-
-## Backend
-
-- Wrap RabbitMQ consumers in try/except
-- Never crash consumer loop
-- Always log structured errors
-
-## Frontend
-
-- Always use global error boundaries
-- Handle API failures explicitly
-- Never silently ignore HTTP errors
-
-
----
-
-# RabbitMQ Rules
-
-- Events must include: `event_type`, `timestamp`, payload object (ver contratos en Business Rules)
-- Consumers must be idempotent
-- Never assume message delivery exactly once
-- Support reconnection logic
-- **Reducción de duplicación:** ~90% del setup de consumidores se duplica entre Assignment y Notification. Al refactorizar, considerar abstracción común (ej. `BaseRabbitMQConsumer`) para evitar código duplicado
-
-
----
-
-# Database Rules
-
-STRICT RULE:
-
-❌ NEVER import models from another microservice  
-❌ NEVER connect to another service DB  
-
-✔ Use REST API  
-✔ Use events  
-
-This is mandatory.
-
-
----
-
-# Testing Standards
-
-Backend:
-
-- Unit tests for domain logic required
-- Avoid Django dependency in domain tests
-
-Frontend:
-
-- Use Vitest + React Testing Library
-- Test behavior, not implementation
-
-
----
-
-# Security Standards
-
-Frontend:
-
-- Never store auth tokens in localStorage
-- Prefer HttpOnly cookies strategy
-
-Backend:
-
-- Secrets must come from environment variables
-- Never hardcode credentials
-
-
----
-
-# Documentation Standards
-
-When generating code:
-
-- Add docstrings to public Python functions
-- Add JSDoc for exported TypeScript functions
-- Explain event payload structures
-
-Focus on clarity over verbosity.
-
----
-
-
+- [`notifications/domain/entities.py`](../notifications/domain/entities.py) — `Notification` entity + `mark_as_read()` idempotency logic
+- [`notifications/domain/exceptions.py`](../notifications/domain/exceptions.py) — `NotificationNotFound`, `InvalidEventSchema`, `NotificationAlreadyRead`
+- [`notifications/application/use_cases.py`](../notifications/application/use_cases.py) — all commands and use cases
+- [`notifications/messaging/consumer.py`](../notifications/messaging/consumer.py) — RabbitMQ dispatcher + DLQ setup
+- [`notification_service/test_settings.py`](../notification_service/test_settings.py) — test DB (SQLite in-memory)
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — full contracts, DT-01 to DT-09, API docs


### PR DESCRIPTION
## ¿Qué cambia este PR?

Reescritura completa de `.github/copilot-instructions.md`, reemplazando instrucciones del monorepo `SistemaTickets` por instrucciones específicas para `backend-notification-service`.

## ¿Por qué era necesario?

El archivo anterior describía la estructura del monorepo completo con rutas inexistentes en este repo (`backend/ticket-service`, `backend/assignment-service`, etc.), decía que la arquitectura DDD estaba "en progreso" cuando ya está implementada, y no incluía los contratos reales de eventos verificados en el código.

## Fuentes verificadas

- `notifications/messaging/consumer.py` → contratos reales de los 4 eventos + handlers
- `notifications/serializers.py` → los 5 campos expuestos en la API
- `notifications/models.py` → `user_id` y `response_id` como campos internos
- `notifications/api.py` → patrón DI en `ViewSet.__init__`
- `pytest.ini` → `DJANGO_SETTINGS_MODULE = notification_service.test_settings`

## Cambios

- ✅ Scope acotado a este repo — eliminadas referencias al monorepo
- ✅ Mapa de capas DDD con la **asimetría real**: `ticket.response_added` usa Use Case; el resto usa ORM directo (DT-01)
- ✅ Contratos de los 4 eventos con campos confirmados del código
- ✅ Schema REST: 5 campos, `ticket_id` como `string`, `user_id`/`response_id` como internos no expuestos
- ✅ Patrón Command + Use Case con ejemplo concreto de DI
- ✅ Workflows: `pytest` usa `test_settings`, consumer es proceso standalone
- ✅ Referencias a archivos clave del repo

## Issue relacionado

Closes #7