### PR TITLE
[ISSUE-11] DT-02: Fix host hardcodeado en test_integration.py

### DIFF
--- a/notifications/tests/test_integration.py
+++ b/notifications/tests/test_integration.py
@@ -4,12 +4,13 @@ Prueban la integración con RabbitMQ y el flujo completo del sistema.
 """
 
 import json
+import os
 import pika
 import time
 from django.test import TestCase
 from notifications.models import Notification
 
-RABBIT_HOST = 'rabbitmq'
+RABBIT_HOST = os.environ.get('RABBITMQ_HOST', 'localhost')
 QUEUE_NAME = 'ticket_created'
 
 


### PR DESCRIPTION
## Descripcion
Reemplaza el host hardcodeado 'rabbitmq' por una variable de entorno con fallback a 'localhost'.

## Cambio
notifications/tests/test_integration.py:
- Antes: RABBIT_HOST = 'rabbitmq'
- Despues: RABBIT_HOST = os.environ.get('RABBITMQ_HOST', 'localhost')
- Agrega import os faltante

## Impacto
- Tests de integracion no rompen CI por ausencia del host 'rabbitmq'
- Docker sigue funcionando con RABBITMQ_HOST=rabbitmq en el entorno
- Alineado con la configuracion del consumer.py que ya usaba os.environ.get

## Issue relacionado
Closes #11

## Checklist
- [x] Tests unitarios agregados/actualizados
- [x] Sin imports de otros servicios via ORM
- [x] Lógica de negocio en dominio o use cases (no en views/consumer)
- [x] Type hints en funciones publicas
- [x] Docstrings en funciones publicas