### PR TITLE
[ISSUE-15] DT-05: Dockerfile con usuario no-root (US-INFRA-01)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,23 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt /app/
+# Instalar dependencias de produccion antes de copiar el codigo
+# para aprovechar la cache de capas de Docker
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . /app/
+# Copiar el codigo fuente
+COPY . .
 
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+# Crear usuario de sistema sin privilegios de root [DT-05 / US-INFRA-01]
+# El proceso NO corre como root, reduciendo la superficie de ataque
+RUN addgroup --system appgroup \
+    && adduser --system --ingroup appgroup --no-create-home appuser \
+    && chown -R appuser:appgroup /app \
+    && chmod +x /app/entrypoint.sh
+
+USER appuser
 
 EXPOSE 8000
 
-CMD ["sh", "/app/entrypoint.sh"]
+CMD ["/app/entrypoint.sh"]


### PR DESCRIPTION
﻿## Descripcion
Optimiza el Dockerfile para cumplir los criterios de aceptacion de US-INFRA-01.
El contenedor ahora corre como un usuario de sistema sin privilegios root.

## Cambios en Dockerfile
- Antes: corre como root (sin USER) -> Ahora: USER appuser sin privilegios
- Antes: COPY entrypoint.sh duplicado -> Ahora: solo COPY . . (incluye entrypoint.sh)
- Antes: CMD sh wrapper -> Ahora: CMD exec form directo
- Nuevo: chown -R appuser:appgroup /app garantiza acceso al directorio de trabajo

## Criterios cumplidos (US-INFRA-01)
- Scenario 1: imagen python:3.12-slim + deps produccion menor a 300MB
- Scenario 2: whoami no retorna root dentro del contenedor

## Issue relacionado
Closes #15

## Checklist
- Tests unitarios agregados/actualizados
- Sin imports de otros servicios via ORM
- Logica de negocio en dominio o use cases
- Type hints en funciones publicas
- Docstrings en funciones publicas
